### PR TITLE
Add defaults and checking for per_cell and per_tile

### DIFF
--- a/adjust_restart_for_new_land_cover/adjust_restart_for_new_land_cover.py
+++ b/adjust_restart_for_new_land_cover/adjust_restart_for_new_land_cover.py
@@ -55,11 +55,21 @@ def prepare_mapping(nVeg, ConfigFile):
     with open(ConfigFile, 'r') as conf:
         MappingConf = yaml.safe_load(conf)
 
-    # At the moment, the only thing that requires defaults is the input to
-    # output vegetation mapping. By default, it maps in a 1-to-1 manner, i.e.
+    # By default, the vegetation maps in a 1-to-1 manner, i.e.
     # vegetation type 1 in the old vegetation map maps to vegetation type 1 in
     # the new vegetation map.
     VegetationMapping = {i: [i] for i in range(nVeg)}
+
+    # It may be that the user removes either per_tile or per_cell entries in
+    # the config- apply default values (empty list) that are iterable in that
+    # case. Also, ensure that it's a list instance
+    MappingConf['per_cell'] = MappingConf.get('per_cell', [])
+    if not isinstance(MappingConf['per_cell'], list):
+        MappingConf['per_cell'] = [MappingConf['per_cell']]
+
+    MappingConf['per_tile'] = MappingConf.get('per_tile', [])
+    if not isinstance(MappingConf['per_tile'], list):
+        MappingConf['per_tile'] = [MappingConf['per_tile']]
 
     # Apply the supplied mappings
     if 'vegetation_map' in MappingConf:

--- a/adjust_restart_for_new_land_cover/adjust_restart_for_new_land_cover.py
+++ b/adjust_restart_for_new_land_cover/adjust_restart_for_new_land_cover.py
@@ -63,11 +63,11 @@ def prepare_mapping(nVeg, ConfigFile):
     # It may be that the user removes either per_tile or per_cell entries in
     # the config- apply default values (empty list) that are iterable in that
     # case. Also, ensure that it's a list instance
-    MappingConf['per_cell'] = MappingConf.get('per_cell', [])
+    MappingConf['per_cell'] = MappingConf.get('per_cell') or []
     if not isinstance(MappingConf['per_cell'], list):
         MappingConf['per_cell'] = [MappingConf['per_cell']]
 
-    MappingConf['per_tile'] = MappingConf.get('per_tile', [])
+    MappingConf['per_tile'] = MappingConf.get('per_tile') or []
     if not isinstance(MappingConf['per_tile'], list):
         MappingConf['per_tile'] = [MappingConf['per_tile']]
 


### PR DESCRIPTION
The restart adjustment script would fail if the user decided to remove either the `per_cell` or `per_tile` entries in the config, which are valid choices to make. This adds handling for that case, and ensures that the values supplied for this entry are iterable as expected by the rest of the script.

@NortonAlex is currently testing this.